### PR TITLE
Fix undefined flag bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ SET(SLAMBENCH_INCLUDE_DIR  ${EIGEN3_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/framework/s
 SET(SLAMBENCH_LIBRARIES    slambench-utils         -Wl,${WHOLE_ARCHIVE_ON} slambench-io                slambench-metrics  -Wl,${WHOLE_ARCHIVE_OFF})
 
 IF (APPLE)
-    SET(SLAMBENCH_C_WRAPPER  -undefined dynamic_lookup -Wl,${WHOLE_ARCHIVE_ON} slambench-c-wrapper                            -Wl,${WHOLE_ARCHIVE_OFF})
+    SET(SLAMBENCH_C_WRAPPER  "-undefined dynamic_lookup" -Wl,${WHOLE_ARCHIVE_ON} slambench-c-wrapper                            -Wl,${WHOLE_ARCHIVE_OFF})
  ELSE ()
     SET(SLAMBENCH_C_WRAPPER                            -Wl,${WHOLE_ARCHIVE_ON} slambench-c-wrapper                            -Wl,${WHOLE_ARCHIVE_OFF})
 ENDIF ()


### PR DESCRIPTION
Should allow SLAMBench to be compiled on OSX.